### PR TITLE
fixed gcc print-multi-os-dir flag

### DIFF
--- a/msp430-gcc.rb
+++ b/msp430-gcc.rb
@@ -74,7 +74,7 @@ class Msp430Gcc < Formula
       # http://msp430-gcc-users.1086195.n5.nabble.com/overwriting-libiberty-td4215.html
       # Fix inspired by:
       # https://github.com/larsimmisch/homebrew-avr/commit/8cc2a2e591b3a4bef09bd6efe2d7de95dfd92794
-      multios = `gcc --print-multi-os-dir`.chomp
+      multios = `gcc --print-multi-os-directory`.chomp
       File.unlink "#{prefix}/lib/#{multios}/libiberty.a"
     end
   end


### PR DESCRIPTION
Hope this is helpful. It resolved the compilation error I was getting on OSX Maverics using gcc (command line tools version of gcc: Apple LLVM version 5.1 (clang-503.0.38) (based on LLVM 3.4svn) Target: x86_64-apple-darwin13.1.0)
