### PR TITLE
Use the `gcc —print-multi-os-directory` option to determine the correct directory

### DIFF
--- a/msp430-gcc.rb
+++ b/msp430-gcc.rb
@@ -47,11 +47,8 @@ class Msp430Gcc < Formula
       # http://msp430-gcc-users.1086195.n5.nabble.com/overwriting-libiberty-td4215.html
       # Fix inspired by:
       # https://github.com/larsimmisch/homebrew-avr/commit/8cc2a2e591b3a4bef09bd6efe2d7de95dfd92794
-      if File.exists?("#{prefix}/lib/x86_64/libiberty.a")
-        File.unlink "#{prefix}/lib/x86_64/libiberty.a"
-      else
-        File.unlink "#{prefix}/lib/libiberty.a"
-      end
+      multios = `gcc --print-multi-os-directory`.chomp
+      File.unlink "#{prefix}/lib/#{multios}/libiberty.a"
     end
   end
 end


### PR DESCRIPTION
Reverted back to the version as it has been before https://github.com/sampsyo/homebrew-mspgcc/commit/154da1ed517a0e226297121e6ba46c0fd3b676e8#diff-839533bbb33c5e4b20549fd2d42664bfR49

Looks like a better solution, than to hardcode for x86_64 or anything else.