### PR TITLE
Use sha256 as sha1 is deprecated

### DIFF
--- a/msp430-binutils.rb
+++ b/msp430-binutils.rb
@@ -1,19 +1,13 @@
 require 'formula'
 
-class Mspgcc < Formula
-  homepage 'http://mspgcc.sourceforge.net'
-  url 'http://downloads.sourceforge.net/project/mspgcc/mspgcc/DEVEL-4.7.x/mspgcc-20120911.tar.bz2'
-  sha1 '04f5860857dbb166d997737312494018b125f4bd'
-end
-
 class Msp430Binutils < Formula
   homepage 'http://mspgcc.sourceforge.net'
   url 'http://ftp.gnu.org/gnu/binutils/binutils-2.22.tar.gz'
-  sha1 '0e16a7492c0a194962ecd33fc80fa53ccfec5149'
+  sha256 "12c26349fc7bb738f84b9826c61e103203187ca2d46f08b82e61e21fcbc6e3e6"
 
   patch do
     url "http://sourceforge.net/projects/mspgcc/files/Patches/binutils-2.22/msp430-binutils-2.22-20120911.patch/download"
-    sha1 "5b3aec605f85fea81a22aa52e9900a5e2f9cc460"
+    sha256 "1dc3cfb0eac093b5f016f4264b811b4352515e8a3519c91240c73bacd256a667"
   end
 
   def install

--- a/msp430-gcc.rb
+++ b/msp430-gcc.rb
@@ -1,15 +1,9 @@
 require 'formula'
 
-class Mspgcc < Formula
-  homepage 'http://mspgcc.sourceforge.net'
-  url ' http://downloads.sourceforge.net/project/mspgcc/mspgcc/DEVEL-4.7.x/mspgcc-20120911.tar.bz2'
-  sha1 '04f5860857dbb166d997737312494018b125f4bd'
-end
-
 class Msp430Gcc < Formula
   homepage 'http://mspgcc.sourceforge.net'
   url 'http://www.netgull.com/gcc/releases/gcc-4.7.0/gcc-4.7.0.tar.bz2'
-  sha1 '03b8241477a9f8a34f6efe7273d92b9b6dd9fe82'
+  sha256 "a680083e016f656dab7acd45b9729912e70e71bbffcbf0e3e8aa1cccf19dc9a5"
   env :std
 
   depends_on 'msp430-binutils'
@@ -20,7 +14,7 @@ class Msp430Gcc < Formula
 
   patch do
     url "http://sourceforge.net/projects/mspgcc/files/Patches/gcc-4.7.0/msp430-gcc-4.7.0-20120911.patch/download"
-    sha1 "3e70230f6052ed30d1a288724f2b97ab47581489"
+    sha256 "db0b6e502c89be4cfee518e772125eaea66cc289d9428c57ddcc187a3be9e77a"
   end
 
   def install

--- a/msp430-gdb.rb
+++ b/msp430-gdb.rb
@@ -1,19 +1,14 @@
 require 'formula'
 
-class Mspgcc < Formula
-  homepage 'http://mspgcc.sourceforge.net'
-  url 'http://downloads.sourceforge.net/project/mspgcc/mspgcc/DEVEL-4.7.x/mspgcc-20120911.tar.bz2'
-  sha1 '04f5860857dbb166d997737312494018b125f4bd'
-end
-
 class Msp430Gdb < Formula
   homepage 'http://mspgcc.sourceforge.net'
   url 'http://ftpmirror.gnu.org/gdb/gdb-7.2a.tar.bz2'
-  sha1 '14daf8ccf1307f148f80c8db17f8e43f545c2691'
+  sha256 "3c24dde332e33bfe2d5980c726d76224ebf8304278112a07bf701f8d2145d9bc"
   env :std
 
   patch do
     url "http://sourceforge.net/projects/mspgcc/files/Patches/gdb-7.2a/msp430-gdb-7.2a-20111205.patch/download"
+    sha256 "b70b54df5e00d24a3a5b744545a87ce656bdc88546081c6ffabefbc4d6c42956"
   end
 
   def install

--- a/msp430-libc.rb
+++ b/msp430-libc.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Msp430Libc < Formula
   homepage 'http://mspgcc.sourceforge.net'
   url 'https://sourceforge.net/projects/mspgcc/files/msp430-libc/msp430-libc-20120716.tar.bz2'
-  sha1 '2ab5be8e645a5e96f64de9dd45ce96d129180ed1'
+  sha256 "cbd78f468e9e3b2df9060f78e8edb1b7bfeb98a9abfa5410d23f63a5dc161c7d"
 
   depends_on 'msp430-gcc'
   depends_on 'msp430-mcu'

--- a/msp430-mcu.rb
+++ b/msp430-mcu.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Msp430Mcu < Formula
   homepage 'http://mspgcc.sourceforge.net'
   url 'http://sourceforge.net/projects/mspgcc/files/msp430mcu/msp430mcu-20120406.tar.bz2'
-  sha1 'c096eec84f0f287c45db713a550ec50c518fa065'
+  sha256 "0637014e8e509746c3f6df8e1d65b786770d162b3a0b86548bdf76ac3102c96e"
 
   def install
     # Create the "bin" directory for installation. The install.sh script


### PR DESCRIPTION
Update all sha1 instances to use sha256 instead,
as the latest version of homebrew throws warnings about
the sha1 use.

Also remove surplus Mspgcc formula definition.