### PR TITLE
Update formulae as suggested by brew style and brew audit

### DIFF
--- a/msp430-binutils.rb
+++ b/msp430-binutils.rb
@@ -1,20 +1,18 @@
-require 'formula'
-
 class Msp430Binutils < Formula
-  homepage 'http://mspgcc.sourceforge.net'
-  url 'http://ftp.gnu.org/gnu/binutils/binutils-2.22.tar.gz'
+  homepage "http://mspgcc.sourceforge.net"
+  url "https://ftpmirror.gnu.org/binutils/binutils-2.22.tar.gz"
   sha256 "12c26349fc7bb738f84b9826c61e103203187ca2d46f08b82e61e21fcbc6e3e6"
 
   patch do
-    url "http://sourceforge.net/projects/mspgcc/files/Patches/binutils-2.22/msp430-binutils-2.22-20120911.patch/download"
+    url "https://downloads.sourceforge.net/project/mspgcc/Patches/binutils-2.22/msp430-binutils-2.22-20120911.patch"
     sha256 "1dc3cfb0eac093b5f016f4264b811b4352515e8a3519c91240c73bacd256a667"
   end
 
   def install
-    mkdir 'build' do
+    mkdir "build" do
       system "../configure", "--target=msp430", "--program-prefix='msp430-'", "--prefix=#{prefix}"
       system "make"
-      system "make install"
+      system "make", "install"
     end
   end
 end

--- a/msp430-gcc.rb
+++ b/msp430-gcc.rb
@@ -1,19 +1,17 @@
-require 'formula'
-
 class Msp430Gcc < Formula
-  homepage 'http://mspgcc.sourceforge.net'
-  url 'http://www.netgull.com/gcc/releases/gcc-4.7.0/gcc-4.7.0.tar.bz2'
+  homepage "http://mspgcc.sourceforge.net"
+  url "https://ftpmirror.gnu.org/gcc/gcc-4.7.0/gcc-4.7.0.tar.bz2"
   sha256 "a680083e016f656dab7acd45b9729912e70e71bbffcbf0e3e8aa1cccf19dc9a5"
   env :std
 
-  depends_on 'msp430-binutils'
-  depends_on 'mpfr'
-  depends_on 'gmp'
-  depends_on 'isl'
-  depends_on 'libmpc'
+  depends_on "msp430-binutils"
+  depends_on "mpfr"
+  depends_on "gmp"
+  depends_on "isl"
+  depends_on "libmpc"
 
   patch do
-    url "http://sourceforge.net/projects/mspgcc/files/Patches/gcc-4.7.0/msp430-gcc-4.7.0-20120911.patch/download"
+    url "https://downloads.sourceforge.net/project/mspgcc/Patches/gcc-4.7.0/msp430-gcc-4.7.0-20120911.patch"
     sha256 "db0b6e502c89be4cfee518e772125eaea66cc289d9428c57ddcc187a3be9e77a"
   end
 
@@ -23,18 +21,17 @@ class Msp430Gcc < Formula
     # configure: error: cannot compute suffix of object files: cannot compile
     # which, upon further inspection, arises when xgcc bails out when it sees
     # this argument.
-    ENV.remove_from_cflags '-Qunused-arguments'
+    ENV.remove_from_cflags "-Qunused-arguments"
     ENV.remove_from_cflags(/ ?-march=\S*/)
     ENV.remove_from_cflags(/ ?-msse[\d\.]*/)
     ENV.remove_from_cflags(/ ?-mmacosx-version-min=10\.\d+/)
 
     # gcc must be built outside of the source directory.
-    mkdir 'build' do
-      binutils = Formula.factory('msp430-binutils')
-      cc = ENV['CC']
+    mkdir "build" do
+      binutils = Formula["msp430-binutils"]
       system "../configure", "--target=msp430", "--enable-languages=c,c++", "--program-prefix='msp430-'", "--prefix=#{prefix}", "--with-as=#{binutils.opt_prefix}/msp430/bin/as", "--with-ld=#{binutils.opt_prefix}/msp430/bin/ld"
       system "make"
-      system "make install"
+      system "make", "install"
 
       # Remove libiberty, which conflicts with the same library provided by
       # binutils.
@@ -42,8 +39,8 @@ class Msp430Gcc < Formula
       # Fix inspired by:
       # https://github.com/larsimmisch/homebrew-avr/commit/8cc2a2e591b3a4bef09bd6efe2d7de95dfd92794
       multios = `gcc --print-multi-os-directory`.chomp
-      libiberty = "#{prefix}/lib/#{multios}/libiberty.a"
-      if File.exists?(libiberty)
+      libiberty = "#{lib}/#{multios}/libiberty.a"
+      if File.exist?(libiberty)
         File.unlink libiberty
       end
     end

--- a/msp430-gdb.rb
+++ b/msp430-gdb.rb
@@ -1,26 +1,24 @@
-require 'formula'
-
 class Msp430Gdb < Formula
-  homepage 'http://mspgcc.sourceforge.net'
-  url 'http://ftpmirror.gnu.org/gdb/gdb-7.2a.tar.bz2'
+  homepage "http://mspgcc.sourceforge.net"
+  url "https://ftpmirror.gnu.org/gdb/gdb-7.2a.tar.bz2"
   sha256 "3c24dde332e33bfe2d5980c726d76224ebf8304278112a07bf701f8d2145d9bc"
   env :std
 
   patch do
-    url "http://sourceforge.net/projects/mspgcc/files/Patches/gdb-7.2a/msp430-gdb-7.2a-20111205.patch/download"
+    url "https://downloads.sourceforge.net/project/mspgcc/Patches/gdb-7.2a/msp430-gdb-7.2a-20111205.patch"
     sha256 "b70b54df5e00d24a3a5b744545a87ce656bdc88546081c6ffabefbc4d6c42956"
   end
 
   def install
-    mkdir 'build' do
-        #supress warnings
-        ENV['CFLAGS']='-Wno-error=return-type -Wno-error=sizeof-pointer-memaccess -Wno-error=sometimes-uninitialized'
-        system "../configure",
-                "--target=msp430",
-                "--program-prefix='msp430-'",
-                "--prefix=#{prefix}"
-        system "make"
-        system "make install"
+    mkdir "build" do
+      # supress warnings
+      ENV["CFLAGS"] = "-Wno-error=return-type -Wno-error=sizeof-pointer-memaccess -Wno-error=sometimes-uninitialized"
+      system "../configure",
+              "--target=msp430",
+              "--program-prefix='msp430-'",
+              "--prefix=#{prefix}"
+      system "make"
+      system "make", "install"
     end
   end
 end

--- a/msp430-libc.rb
+++ b/msp430-libc.rb
@@ -1,24 +1,23 @@
-require 'formula'
-
 class Msp430Libc < Formula
-  homepage 'http://mspgcc.sourceforge.net'
-  url 'https://sourceforge.net/projects/mspgcc/files/msp430-libc/msp430-libc-20120716.tar.bz2'
+  homepage "http://mspgcc.sourceforge.net"
+  url "https://downloads.sourceforge.net/project/mspgcc/msp430-libc/msp430-libc-20120716.tar.bz2"
   sha256 "cbd78f468e9e3b2df9060f78e8edb1b7bfeb98a9abfa5410d23f63a5dc161c7d"
 
-  depends_on 'msp430-gcc'
-  depends_on 'msp430-mcu'
+  depends_on "msp430-gcc"
+  depends_on "msp430-mcu"
 
   def install
     # When building, we need to have the "msp430/bin" directory on the path.
     # This is because, even when we invoke msp430-gcc, it goes looking for a
     # binary called "as". If we don't do this, then it will find the system
     # (i.e., x86) as.
-    binutils = Formula.factory('msp430-binutils')
-    gcc = Formula.factory('msp430-gcc')
+    binutils = Formula["msp430-binutils"]
+    gcc = Formula["msp430-gcc"]
     msppath = "#{binutils.opt_prefix}/msp430/bin:#{gcc.opt_prefix}/msp430/bin"
 
-    Dir.chdir 'src' do
-      system "env", "PATH=#{msppath}:#{ENV['PATH']}", "make"
+    Dir.chdir "src" do
+      ENV.prepend_path "PATH", msppath.to_s
+      system "make"
       system "make", "PREFIX=#{prefix}", "install"
     end
   end

--- a/msp430-mcu.rb
+++ b/msp430-mcu.rb
@@ -1,7 +1,7 @@
 class Msp430Mcu < Formula
   homepage "http://mspgcc.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/mspgcc/msp430mcu/msp430mcu-20120406.tar.bz2"
-  sha256 "0637014e8e509746c3f6df8e1d65b786770d162b3a0b86548bdf76ac3102c96e"
+  url "https://downloads.sourceforge.net/project/mspgcc/msp430mcu/msp430mcu-20130321.tar.bz2"
+  sha256 "01be411f8901362fab32e7e1be044a44e087a98f3bd2346ac167960cfe6fa221"
 
   def install
     # Create the "bin" directory for installation. The install.sh script

--- a/msp430-mcu.rb
+++ b/msp430-mcu.rb
@@ -1,17 +1,15 @@
-require 'formula'
-
 class Msp430Mcu < Formula
-  homepage 'http://mspgcc.sourceforge.net'
-  url 'http://sourceforge.net/projects/mspgcc/files/msp430mcu/msp430mcu-20120406.tar.bz2'
+  homepage "http://mspgcc.sourceforge.net"
+  url "https://downloads.sourceforge.net/project/mspgcc/msp430mcu/msp430mcu-20120406.tar.bz2"
   sha256 "0637014e8e509746c3f6df8e1d65b786770d162b3a0b86548bdf76ac3102c96e"
 
   def install
     # Create the "bin" directory for installation. The install.sh script
     # expects this to exist.
-    Dir.mkdir "#{prefix}/bin"
+    Dir.mkdir bin.to_s
 
     # As suggested by the README.
-    ENV['MSP430MCU_ROOT'] = Dir.pwd
+    ENV["MSP430MCU_ROOT"] = Dir.pwd
     system "./scripts/install.sh", prefix
   end
 end


### PR DESCRIPTION
Use URLs as suggested by brew audit:
Always use https://downloads.sourceforge.net and
https://ftpmirror.gnu.org to get the closest mirror.

Require ‘formula’ is not needed anymore.
Always use double quotes.
Fix some code style warnings.

`brew audit` and `brew style` should now not report warnings anymore.